### PR TITLE
docs: point to published SDLC and unify vulnerability reporting

### DIFF
--- a/PRESIDIO-REQ.md
+++ b/PRESIDIO-REQ.md
@@ -50,3 +50,8 @@ makes this explicit in the output, reinforcing the takeaway that the GCM tag
 *is* the integrity mechanism even when HMAC is off.
 
 <!-- Deliver the complete working project ready for GitHub publish. -->
+
+## SDLC
+
+These requirements are delivered under the family-wide Presidio SDLC:
+<https://github.com/presidio-v/presidio-hardened-docs/blob/main/sdlc/sdlc-report.md>.

--- a/README.md
+++ b/README.md
@@ -69,3 +69,10 @@ src/presidio_crypto_channel/
 ## License
 
 MIT
+
+---
+
+## SDLC
+
+This repository is developed under the Presidio hardened-family SDLC:
+<https://github.com/presidio-v/presidio-hardened-docs/blob/main/sdlc/sdlc-report.md>.

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -8,14 +8,18 @@
 
 ## Reporting a Vulnerability
 
-Do not open a public GitHub issue for security vulnerabilities.
+Please report security vulnerabilities by opening a private GitHub Security Advisory
+(via the "Security" tab → "Report a vulnerability") rather than a public issue.
 
-Email **security@presidio-group.eu** with:
+Include:
+
 - Description of the vulnerability
 - Steps to reproduce
 - Potential impact
+- Suggested fix (if any)
 
-You will receive an acknowledgement within 48 hours and a resolution within 7 days.
+You will receive an acknowledgement within 5 business days. We aim to release a patch
+within 30 days of a confirmed vulnerability.
 
 ## Security Features
 
@@ -33,3 +37,9 @@ You will receive an acknowledgement within 48 hours and a resolution within 7 da
 - Dependabot monitors dependencies weekly.
 - CodeQL runs on every push and on a weekly schedule.
 - The only non-dev dependency is `cryptography>=42.0` (PyCA).
+
+## Software Development Lifecycle
+
+This repository is developed under the Presidio hardened-family SDLC. The public report
+— scope, standards mapping, threat-model gates, and supply-chain controls — is at
+<https://github.com/presidio-v/presidio-hardened-docs/blob/main/sdlc/sdlc-report.md>.


### PR DESCRIPTION
## Summary

- Normalize the SECURITY.md Reporting section to the GitHub Security Advisories-only pattern used across the family.
- Add pointers to the published family SDLC in README.md, SECURITY.md, and PRESIDIO-REQ.md.
- SDLC: https://github.com/presidio-v/presidio-hardened-docs/blob/main/sdlc/sdlc-report.md

## Test plan

- [x] Diff scoped to docs files; no source or workflow changes
- [x] Links render on GitHub