### PR TITLE
Trusted Publisher workflow + freeze policy (v0.1.0 release prep)

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,54 @@
+name: Publish to PyPI
+
+# Trusted Publisher (OIDC, no stored secrets) + PEP 740 attestations.
+# Triggered by a signed v* tag. The publish job runs in the `release`
+# environment, which carries a required-reviewer founder gate.
+
+on:
+  push:
+    tags:
+      - "v*"
+
+permissions:
+  contents: read
+
+jobs:
+  build:
+    name: Build distribution
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+      - name: Build sdist and wheel
+        run: |
+          python -m pip install --upgrade pip build
+          python -m build
+      - name: Check metadata
+        run: |
+          python -m pip install --upgrade twine
+          twine check dist/*
+      - uses: actions/upload-artifact@v4
+        with:
+          name: dist
+          path: dist/
+
+  publish:
+    name: Publish to PyPI (Trusted Publishing)
+    needs: build
+    runs-on: ubuntu-latest
+    environment:
+      name: release
+    permissions:
+      id-token: write # OIDC token for PyPI Trusted Publishing + sigstore
+      attestations: write # PEP 740 provenance attestations
+    steps:
+      - uses: actions/download-artifact@v4
+        with:
+          name: dist
+          path: dist/
+      - name: Publish to PyPI
+        uses: pypa/gh-action-pypi-publish@release/v1
+        with:
+          attestations: true

--- a/MAINTENANCE.md
+++ b/MAINTENANCE.md
@@ -1,0 +1,30 @@
+# Maintenance Policy — presidio-hardened-crypto-channel
+
+**Status: Frozen — security-fixes-only** (as of 2026-06-11).
+
+`presidio-hardened-crypto-channel` is published to PyPI and feature-complete for its scope. It
+receives **security fixes only**; no new features are planned. Issues or pull
+requests outside the security scope may be closed with a pointer to this policy.
+
+## Not affiliated with Microsoft Presidio
+
+This project is **independent of Microsoft Presidio** (a data-anonymization
+toolkit). "Presidio" here refers to the PRESIDIO hardened-component family by
+Vladimir Stantchev (GitHub org `presidio-v`).
+
+## Releases & provenance
+
+Releases are published via GitHub Actions **Trusted Publishing** (OIDC — no
+stored API tokens) with **PEP 740 attestations**, and every publish is gated by
+founder approval (the `release` environment required reviewer).
+
+```bash
+pip install presidio-hardened-crypto-channel
+```
+
+PyPI verifies the attached attestations automatically on install for clients
+that support PEP 740.
+
+## Reporting security issues
+
+See [`SECURITY.md`](./SECURITY.md).

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,11 +1,11 @@
 [build-system]
-requires = ["hatchling"]
+requires = ["hatchling", "tomli; python_version < '3.11'"]
 build-backend = "hatchling.build"
 
 [project]
 name = "presidio-hardened-crypto-channel"
 version = "0.1.0"
-description = "Secure cryptographic channel demonstrating ECDH, AES-256-GCM, and HMAC integrity"
+description = "Secure cryptographic channel demonstrating ECDH, AES-256-GCM, and HMAC integrity. Independent of Microsoft Presidio (a data-anonymization toolkit)."
 readme = "README.md"
 license = "MIT"
 requires-python = ">=3.10"


### PR DESCRIPTION
Prepares the first PyPI publish via Trusted Publishing (OIDC + PEP 740), gated by the `release` environment founder approval. Adds MAINTENANCE.md and the Microsoft Presidio disambiguation. Build verified locally (sdist+wheel, twine passed).