### PR TITLE
Raise Python dependency minimums

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,14 +22,14 @@ classifiers = [
     "Topic :: Security :: Cryptography",
 ]
 dependencies = [
-    "cryptography>=42.0",
+    "cryptography>=46.0.7",
 ]
 
 [project.optional-dependencies]
 dev = [
-    "pytest>=7.4",
-    "pytest-cov>=4.1",
-    "ruff>=0.4",
+    "pytest>=9.0.3",
+    "pytest-cov>=7.1.0",
+    "ruff>=0.15.10",
 ]
 
 [project.urls]


### PR DESCRIPTION
## Summary
- Consolidates the open Dependabot Python dependency updates into one manifest change.
- Raises cryptography to >=46.0.7, pytest to >=9.0.3, pytest-cov to >=7.1.0, and ruff to >=0.15.10.
- Leaves workflow and source files unchanged.

## Test plan
- [x] /Users/vstantch/.local/bin/uv sync --extra dev
- [x] .venv/bin/python -m ruff check .
- [x] .venv/bin/python -m ruff format --check .
- [x] .venv/bin/python -m pytest tests/ -x -q --tb=short
- [x] pip-audit --path .venv/lib/python3.13/site-packages

Supersedes #5, #6, #7, and #8.